### PR TITLE
fix: increase backdrop size

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,12 @@
 .review-thread-component .js-reactions-container {
   transform: translate(0px, -10px);
 }
+.js-reactions-container .details-overlay[open] > summary::before {
+  top: -400px;
+  right: -400px;
+  bottom: -400px;
+  left: -400px;
+}
 `
   document.head.appendChild(style)
 })()


### PR DESCRIPTION
This pull request increases the size of the `::before` element that accepts the click for closing the emoji panel.

Normally, this `::before` takes the entire screen (it's using `absolute inset-0`), but since its parent is now absolutely positioned, there's no way (that I know of) to make it take the size of the viewport as before.

As a workaround, this pull request slightly increases its size so you can click on the side of the emoji panel to close it :)